### PR TITLE
Refactor/template/sidebar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ARCIVE_URL = https://github.com/vdaas/vald/archive/v$(LATEST_VERSION).zip
 NEW_VERSION := ${LATEST_VERSION}
 
 DOC_FILES = $(eval DOC_FILES:=$(shell find tmp/vald-$(LATEST_VERSION)/docs -type f -name "*.md" ))$(DOC_FILES)
-NEW_DOC_FILES = $(DOC_FILES:tmp/vald-$(LATEST_VERSION)/docs/%.md=content/v$(LATEST_VERSION)/%.md)
+NEW_DOC_FILES = $(DOC_FILES:tmp/vald-$(LATEST_VERSION)/docs/%.md=content/docs/v$(LATEST_VERSION)/%.md)
 
 all: deploy
 	git add -A;git commit -m fix;git push
@@ -66,10 +66,11 @@ endef
 
 define copy-doc
 	@echo -e "\e[5;33mcopying document files...\e[0m"
-	@cd content && mkdir -p v$(LATEST_VERSION)
-	@cd tmp/vald-$(LATEST_VERSION)/docs && cp -r . ../../../content/v$(LATEST_VERSION)
-	@cp tmp/vald-$(LATEST_VERSION)/CONTRIBUTING.md content/v$(LATEST_VERSION)/contributing.md
-	@cp tmp/vald-$(LATEST_VERSION)/CHANGELOG.md content/v$(LATEST_VERSION)/release-note.md
+	@mkdir -p content/docs
+	@cd content/docs && mkdir -p v$(LATEST_VERSION)
+	@cd tmp/vald-$(LATEST_VERSION)/docs && cp -r . ../../../content/docs/v$(LATEST_VERSION)
+	@cp tmp/vald-$(LATEST_VERSION)/CONTRIBUTING.md content/docs/v$(LATEST_VERSION)/contributing.md
+	@cp tmp/vald-$(LATEST_VERSION)/CHANGELOG.md content/docs/v$(LATEST_VERSION)/release-note.md
 endef
 
 .PHONY: $(NEW_DOC_FILES)
@@ -81,16 +82,11 @@ $(NEW_DOC_FILES): \
 		rm $@ ; \
 	fi
 	@hugo new $@
-	@cat $(patsubst content/v$(LATEST_VERSION)/%.md,tmp/vald-$(LATEST_VERSION)/docs/%.md,$@) >> $@
-	@cp -r content/v$(LATEST_VERSION)/. content/.
+	@cat $(patsubst content/docs/v$(LATEST_VERSION)/%.md,tmp/vald-$(LATEST_VERSION)/docs/%.md,$@) >> $@
+	@cp -r content/docs/v$(LATEST_VERSION)/. content/docs/.
 
 .PHONY: test
 test: $(NEW_DOC_FILES)
-
-define add-prefix-doc
-	@$(eval text := $(shell cat archetypes/default.md))
-	find content/v$(LATEST_VERSION) -type f
-endef
 
 define copy-image
 	@echo -e "\e[5;33mcheck image files...\e[0m"

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -2,5 +2,10 @@
 title: "{{ replace .Name "-" " " | title }}"
 date: {{ .Date }}
 draft: true
+weight: 0
+{{ $path := path.Base (strings.TrimSuffix "/" .File.Dir) }}
+menu:
+  {{ replace $path "-" "" }}:
+    parent: {{ replace $path "-" " " | title }}
 ---
 

--- a/themes/vald/layouts/404.html
+++ b/themes/vald/layouts/404.html
@@ -2,8 +2,8 @@
 <main id="main">
   <div class="error">
   <picture class="error__image">
-    <source type="image/webp" srcset="{{ .Site.BaseURL }}/image/static_image_404.png.webp" width="187.5"/>
-    <img class="features__icon" src="{{ .Site.BaseURL }}/image/static_image_404.png" alt="" width="187.5">
+    <source type="image/webp" srcset="{{ .Site.BaseURL }}/images/static_image_404.png.webp" width="187.5"/>
+    <img class="features__icon" src="{{ .Site.BaseURL }}/images/static_image_404.png" alt="" width="187.5">
   </picture>
    <h1 id="title" class="error__title">404 page not found</h1>
    <p class="error__message"><a class="error__link" href="{{ "/" | relURL }}">Page Top</a></p>

--- a/themes/vald/layouts/_default/baseof.html
+++ b/themes/vald/layouts/_default/baseof.html
@@ -40,10 +40,9 @@
   </head>
 
   <body>
-    {{ partial "header.html" . -}}
+    {{ partial "header.html" . }}
     <main role="main">
-      {{ $isHome := .Page.IsHome }}
-      {{ if not $isHome }}
+      {{ if not .IsHome }}
         <div class="single">
           {{ block "main" . }}{{ end }}
         </div>
@@ -51,6 +50,6 @@
         {{ block "main" . }}{{ end }}
       {{ end }}
     </main>
-    {{ partial "footer.html" . -}}
+    {{ partial "footer.html" . }}
   </body>
 </html>

--- a/themes/vald/layouts/_default/list.html
+++ b/themes/vald/layouts/_default/list.html
@@ -168,7 +168,7 @@
           </a>
         </li>
         <li class="mdl-card">
-          <a href="https://github.com/vdaas/vald/blob/master/docs/user/get-started.md" class="mdl-link">
+          <a href="{{ .Site.BaseURL }}/docs/tutorial/get-started" class="mdl-link">
             <dl class="mdl-card__content">
               <picture class="card-image">
                 <source type="image/webp" srcset="{{ .Site.BaseURL }}/images/learn_img_02.png.webp" />

--- a/themes/vald/layouts/_default/single.html
+++ b/themes/vald/layouts/_default/single.html
@@ -1,9 +1,9 @@
 {{ define "main" }}
-{{ partial "sidebar.html" . -}}
+{{ partial "sidebar.html" . }}
 <div class="content">
   <div class="markdown">
     {{ .Content }}
   </div>
-  {{ partial "toc.html" . -}}
+  {{ partial "toc.html" . }}
 </div>
 {{ end }}

--- a/themes/vald/layouts/partials/footer.html
+++ b/themes/vald/layouts/partials/footer.html
@@ -2,10 +2,10 @@
   <div class="footer__content cf">
     <ul class="footer__list">
       <li class="footer__item">
-        <a href="#concept" class="footer__link">About<br/></a>
+        <a href="{{ .Site.BaseURL }}/overview/about-vald" class="footer__link">About<br/></a>
       </li>
       <li class="footer__item">
-        <a href="https://github.com/vdaas/vald/blob/master/docs/user/get-started.md" class="footer__link">Getstarted<br/></a>
+        <a href="{{ .Site.BaseURL }}/docs/tutorial/get-started.md" class="footer__link">Getstarted<br/></a>
       </li>
       <li class="footer__item">
         <a href="" class="footer__link">Docs<br/></a>

--- a/themes/vald/layouts/partials/header.html
+++ b/themes/vald/layouts/partials/header.html
@@ -1,4 +1,3 @@
-
 <header class="header" id="header">
   <div class="header__content">
     <nav class="header__nav cf">
@@ -8,10 +7,10 @@
       <a class="header-nav__icon" id="nav-btn"><span class="header-nav__button"></span></a>
       <ul class="header__list" id="menu">
         <li class="header__item">
-          <a href="#concept" class="header__link">About</a>
+          <a href="{{ .Site.BaseURL }}/overview/about-vald" class="header__link">About</a>
         </li>
         <li class="header__item">
-          <a href="https://github.com/vdaas/vald/blob/master/docs/user/get-started.md" class="header__link">Getstarted</a>
+          <a href="{{ .Site.BaseURL }}/docs/tutorial/get-started" class="header__link">Get Started</a>
         </li>
         <li class="header__item">
           <a href="" class="header__link">Docs</a>

--- a/themes/vald/layouts/partials/menu.html
+++ b/themes/vald/layouts/partials/menu.html
@@ -1,0 +1,13 @@
+{{ $current := .current }}
+{{ range .menu }}
+  <li class="withchild">
+    {{- .Name -}}
+    {{ if .HasChildren  }}
+      {{ if not (in $current "docs/v") }}
+        {{ partial "menu/default.html" (dict "children" .Children "current" $current) . -}}
+      {{ else }}
+        {{ partial "menu/version.html" (dict "children" .Children "current" $current) . -}}
+      {{ end }}
+    {{ end }}
+  </li>
+{{ end }}

--- a/themes/vald/layouts/partials/menu/default.html
+++ b/themes/vald/layouts/partials/menu/default.html
@@ -1,0 +1,11 @@
+{{ $current := .current }}
+{{ range .children }}
+  {{ if not ( in .URL "docs/v" ) }}
+    {{ $permalink := absURL .URL }}
+    <ul>
+      <li class="{{ if eq $current $permalink }}view{{ else }}index{{ end }}">
+        <a href="{{ .URL }}">{{ .Name }}</a>
+      </li>
+   </ul>
+  {{ end }}
+{{ end }}

--- a/themes/vald/layouts/partials/menu/version.html
+++ b/themes/vald/layouts/partials/menu/version.html
@@ -1,0 +1,13 @@
+{{ $current := .current }}
+{{ $validPath := split ($current | relLangURL) "/" }}
+{{ $path := index $validPath 2 }}
+{{ range .children }}
+   {{ $permalink := absURL .URL }}
+   {{ if in .URL $path }}
+   <ul>
+     <li class="{{ if eq $current $permalink }}view{{ else }}index{{ end }}">
+       <a href="{{ .URL }}">{{ .File.Path }}</a>
+     </li>
+  </ul>
+  {{ end }}
+{{ end }}

--- a/themes/vald/layouts/partials/sidebar.html
+++ b/themes/vald/layouts/partials/sidebar.html
@@ -1,26 +1,19 @@
 <!-- sidebar start -->
+<!-- TODO: attach class "open" nav -->
 <aside class="page">
   {{ $current := .Page.Permalink }}
-  <!-- TODO: attach class "open" to nav-->
+  <nav class="open">
+    <button class="index" id="list-button">Pages</button>
+    <ul id="list-body">
+      {{ partial "menu.html" (dict "menu" .Site.Menus.overview "current" $current) -}}
+      {{ partial "menu.html" (dict "menu" .Site.Menus.tutorial "current" $current) -}}
+      {{ partial "menu.html" (dict "menu" .Site.Menus.userguides "current" $current) -}}
+      {{ partial "menu.html" (dict "menu" .Site.Menus.usecase "current" $current) -}}
+      {{ partial "menu.html" (dict "menu" .Site.Menus.performance "current" $current) -}}
+      {{ partial "menu.html" (dict "menu" .Site.Menus.contributing "current" $current) -}}
+      {{ partial "menu.html" (dict "menu" .Site.Menus.support "current" $current) -}}
+      {{ partial "menu.html" (dict "menu" .Site.Menus.release "current" $current) -}}
+    </ul>
   <nav>
-  <button class="index" id="list-button">Pages</button>
-    {{ $invalidURL := strings.TrimSuffix "/" .Site.BaseURL }}
-    {{ $invalidURL = print $invalidURL "/v" }}
-  <ul>
-    <!-- TODO: child style withchild, view -->
-    {{ range .Site.Pages }}
-      {{ if not ( in .Permalink $invalidURL) }}
-      {{ if eq $current .Permalink }}
-          <li class="view">
-            <a href="{{ .Permalink }}">{{ .Title }}</a>
-          </li>
-        {{ else }}
-          <li>
-            <a href="{{ .Permalink }}">{{ .Title }}</a>
-          </li>
-        {{ end }}
-      {{ end }}
-    {{end}}
-  </ul>
-  </nav>
 </aside>
+<!-- sidebar end -->


### PR DESCRIPTION
I refactored sidebar template:
  - update `archtype/default.md` for using menu which is hugo's feature
  - fix `Makefile` to change docs directory `$root/docs/..` from `$root/..`
  - separate sidebar template per version:
    - but, it has a below problem. I'll fix it later (another PR). It occurs because of same content's title
      ```bash
      WARN 2020/06/03 17:20:28 "/Users/kyukawa/go/src/github.com/vdaas/web/content/docs/v0.0.37/guides/configurations.md:1:1": duplicate menu entry with identifier "Configurations" in menu "guides"
      WARN 2020/06/03 17:20:28 "/Users/kyukawa/go/src/github.com/vdaas/web/content/docs/v0.0.37/user/get-started.md:1:1": duplicate menu entry with identifier "Get Started" in menu "user"
      ```