### PR TITLE
fix css bug og  lp-first view on ie11

### DIFF
--- a/themes/vald/static/css/main.css
+++ b/themes/vald/static/css/main.css
@@ -32,6 +32,8 @@
 
 .top__bg {
   position: absolute;
+  top:0;
+  left:0;
   width: 100%;
   height: 100%;
 }


### PR DESCRIPTION
lp first view can't be seen on ie 11.
"top" and "left" property is necesseary with "position absolute" in ie