### PR TITLE
add doc image header as a draft

### DIFF
--- a/themes/vald/layouts/_default/list.html
+++ b/themes/vald/layouts/_default/list.html
@@ -1,78 +1,86 @@
 {{ define "main" }}
 {{ $current := .Page.Permalink }}
 {{ partial "sidebar.html" . }}
-<div class="content">
+<!--<div class="content">-->
   {{ if gt (len .Content) 0 }}
+  <div class="content">
     <div class="markdown">
       {{ .Content }}
     </div>
     {{ partial "toc.html" . }}
-  {{ else }}
-  <div class="markdown">
-    <h1>Document Overview</h1>
-    {{ if ne .Page.RelPermalink "/docs/" }}
-    <div class="caution">
-      <p>This Documents are for <strong>{{ index ($arr := split .Page.RelPermalink "/" ) 2 }}</strong>.</p>
-    </div>
-    {{ end }}
-    <p>
-      There is a list of documents about Vald.<br>
-      Let's try to check the documents that you want to know.
-    </p>
-
-    <h2>Overview</h2>
-      <p>
-        Overview shows the concept of Vald and mentions the top level design of Vald.
-      </p>
-      {{ partial "list.html" (dict "menu" .Site.Menus.overview "current" $current) -}}
-
-    <h2>Tutorial</h2>
-      <p>
-        Tutorial takes you Vald World!!!<br>
-        You can deploy Vald in your Kubernetes cluster and running Vald with sample code.
-      </p>
-      {{ partial "list.html" (dict "menu" .Site.Menus.tutorial "current" $current) -}}
-
-    <h2>Usecase</h2>
-      <p>
-        Usecase supports you to imagine how to use Vald for your services.<br>
-        Also, you can get the introduction examples.
-      </p>
-      {{ partial "list.html" (dict "menu" .Site.Menus.usecase "current" $current) -}}
-
-    <h2>User Guides</h2>
-      <p>
-        If you'd like to configure for your Vald Cluster or wonder how to operate, you can find out the answer from these documents.
-      </p>
-      {{ partial "list.html" (dict "menu" .Site.Menus.userguides "current" $current) -}}
-
-    <h2>APIs</h2>
-      <p>
-        Vald provides Insert, Update, Upsert, Search, and Delete APIs.<br>
-        Each API to use with gRPC for request to the Vald Cluster.<br>
-        Each document describes the definition of API, which helps you to use Vald Official Client.
-      </p>
-      {{ partial "list.html" (dict "menu" .Site.Menus.api "current" $current) -}}
-
-    <h2>Troubleshooting</h2>
-      <p>
-        When you encounter any problem, please refer to these documents and try to resolve it.
-      </p>
-      {{ partial "list.html" (dict "menu" .Site.Menus.troubleshooting "current" $current) -}}
-
-    <h2>Contributing</h2>
-      <p>
-        We are welcome to contribute to Vald even not as a developer.<br>
-        Please make sure, how to contribute to Vald.
-      </p>
-      {{ partial "list.html" (dict "menu" .Site.Menus.contributing "current" $current) -}}
-
-    <h2>Support</h2>
-      <p>
-        When wondering anything about Vald, please contact to us via Slack or Github.
-      </p>
-      {{ partial "list.html" (dict "menu" .Site.Menus.support "current" $current) -}}
   </div>
-  {{ end }}
-</div>
+  {{ else }}
+  <div class="content__wrapper content__wrapper-header">
+    <div class="content__header">
+      <p>Let's Start Vald</p>
+      <span>
+        There is a list of documents about Vald.<br>
+        Let's try to check the documents that you want to know.
+      </span>
+    </div>
+    <div class="content">
+      <div class="markdown">
+        <h1>Document Overview</h1>
+        {{ if ne .Page.RelPermalink "/docs/" }}
+        <div class="caution">
+          <p>This Documents are for <strong>{{ index ($arr := split .Page.RelPermalink "/" ) 2 }}</strong>.</p>
+        </div>
+        {{ end }}
+
+        <h2>Overview</h2>
+          <p>
+            Overview shows the concept of Vald and mentions the top level design of Vald.
+          </p>
+          {{ partial "list.html" (dict "menu" .Site.Menus.overview "current" $current) -}}
+
+        <h2>Tutorial</h2>
+          <p>
+            Tutorial takes you Vald World!!!<br>
+            You can deploy Vald in your Kubernetes cluster and running Vald with sample code.
+          </p>
+          {{ partial "list.html" (dict "menu" .Site.Menus.tutorial "current" $current) -}}
+
+        <h2>Usecase</h2>
+          <p>
+            Usecase supports you to imagine how to use Vald for your services.<br>
+            Also, you can get the introduction examples.
+          </p>
+          {{ partial "list.html" (dict "menu" .Site.Menus.usecase "current" $current) -}}
+
+        <h2>User Guides</h2>
+          <p>
+            If you'd like to configure for your Vald Cluster or wonder how to operate, you can find out the answer from these documents.
+          </p>
+          {{ partial "list.html" (dict "menu" .Site.Menus.userguides "current" $current) -}}
+
+        <h2>APIs</h2>
+          <p>
+            Vald provides Insert, Update, Upsert, Search, and Delete APIs.<br>
+            Each API to use with gRPC for request to the Vald Cluster.<br>
+            Each document describes the definition of API, which helps you to use Vald Official Client.
+          </p>
+          {{ partial "list.html" (dict "menu" .Site.Menus.api "current" $current) -}}
+
+        <h2>Troubleshooting</h2>
+          <p>
+            When you encounter any problem, please refer to these documents and try to resolve it.
+          </p>
+          {{ partial "list.html" (dict "menu" .Site.Menus.troubleshooting "current" $current) -}}
+
+        <h2>Contributing</h2>
+          <p>
+            We are welcome to contribute to Vald even not as a developer.<br>
+            Please make sure, how to contribute to Vald.
+          </p>
+          {{ partial "list.html" (dict "menu" .Site.Menus.contributing "current" $current) -}}
+
+        <h2>Support</h2>
+          <p>
+            When wondering anything about Vald, please contact to us via Slack or Github.
+          </p>
+          {{ partial "list.html" (dict "menu" .Site.Menus.support "current" $current) -}}
+      </div><!--markdown-->
+    {{ end }}
+    </div><!--content-->
+  </div><!--content_wrapper-->
 {{ end }}

--- a/themes/vald/static/css/main.css
+++ b/themes/vald/static/css/main.css
@@ -699,6 +699,32 @@ details > summary {
   position: relative;
 }
 
+.content__wrapper {
+  display: flex;
+  flex-direction: column;
+}
+
+.content__header {
+  width: 100%;
+  height: 200px;
+  background-image: url("../images/graphic.png");
+  display: flex;
+  align-items: left;
+  background-size: cover;
+  background-position: center;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.content__header p{
+  font-size: 32px;
+  margin-left: 40px;
+}
+
+.content__header span{
+  margin-left: 40px;
+}
+
 /*current*/
 .current {
   position: fixed;
@@ -1156,7 +1182,6 @@ details > summary {
   .page {
     width: 20%;
     margin-bottom: 0;
-    margin-right: 2%;
   }
 
   .content {
@@ -1164,6 +1189,7 @@ details > summary {
     display: -ms-flexbox;
     display: flex;
     width: 76%;
+    padding-left: 2%;
   }
 
   .markdown {


### PR DESCRIPTION
add an image background header to the  document landing page
and also add column items of most read pages.

![20231127_sc_before](https://github.com/vdaas/web/assets/21119375/2513c30d-fbbc-4e5d-83ae-b7a1988ed5a5)
![20231127_sc_after](https://github.com/vdaas/web/assets/21119375/1b053606-5456-4022-8321-46b3d28ef278)
