### PR TITLE
Create dead link checker workflow

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -24,7 +24,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v1
         with:
-          args: --base ./content/docs ./content/docs/**/*.md --exclude https://github.com/vdaas/*
+          args: --base ./public/docs ./public/docs/**/*.html --exclude https://github.com/vdaas/*
           output: ./check.md
           fail: false
       - name: Create Issue From File

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -15,9 +15,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup
         run: |
+          git submodule init
           make subup
-          cd public && git pull origin gh-pages
-          ls -la ./public/docs
       - name: Link Check
         id: lychee
         uses: lycheeverse/lychee-action@v1

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -16,7 +16,8 @@ jobs:
       - name: Setup
         run: |
           make subup
-          ls -la ./public
+          cd public && git pull origin gh-pages
+          ls -la ./public/docs
       - name: Link Check
         id: lychee
         uses: lycheeverse/lychee-action@v1

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup
         run: |
           make subup
-          ls -la ./public/docs
+          ls -la ./public
       - name: Link Check
         id: lychee
         uses: lycheeverse/lychee-action@v1

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -16,12 +16,12 @@ jobs:
       - name: Setup
         run: |
           make subup
-          ls -la
+          ls -la ./public/docs
       - name: Link Check
         id: lychee
         uses: lycheeverse/lychee-action@v1
         with:
-          args: --base . ./public/docs/* --exclude https://github.com/vdaas/vald/*
+          args: --base . --verbose './public/docs/**/*.html' --exclude https://github.com/vdaas/*
           output: ./check.md
           fail: false
       - name: Create Issue From File

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Setup
         run: |
           make subup
+          ls -la
       - name: Link Check
         id: lychee
         uses: lycheeverse/lychee-action@v1

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -24,7 +24,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v1
         with:
-          args: --base ./public/docs --verbose './public/docs/**/index.html' --exclude https://github.com/vdaas/*
+          args: --base ./public/docs ./public/docs/**/index.html --exclude https://github.com/vdaas/*
           output: ./check.md
           fail: false
       - name: Create Issue From File

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -4,31 +4,32 @@ on:
   pull_request:
   schedule:
     - cron: "0 0 * * *"
-
 env:
   GITHUB_USER: ${{ secrets.DISPATCH_USER }}
   GITHUB_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
-
 jobs:
   linkCheck:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions
         uses: actions/checkout@v4
+      - name: Setup
+        run: |
+          make subup
       - name: Link Check
         id: lychee
-        uses: lycheeverse/lychee-actions@v1
+        uses: lycheeverse/lychee-action@v1
         with:
-          args: --base https://vald.vdaas/org/docs
-          output: ./result.md
+          args: --base . ./public/docs/* --exclude https://github.com/vdaas/vald/*
+          output: ./check.md
           fail: false
       - name: Create Issue From File
         if: env.lychee_exit_code != 0 && github.event_name != 'pull_request'
         run: |
           ISSUE_TITLE="Dead Links were detected"
           gh issue create --title ISSUE_TITLE \
-                          --body-file ./result.md
+                          --body-file ./check.md
       - name: Add Comment On Pull Request From File
         if: env.lychee_exit_code != 0 && github.event_name == 'pull_request'
         run: |
-          gh pr comment ${{ github.event.number }} --body-file ./result.md
+          gh pr comment ${{ github.event.number }} --body-file ./check.md

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -15,8 +15,11 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup
         run: |
-          git submodule init
-          make subup
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
+          git config --global user.name "vdaas-ci"
+          git config --global user.email "ci@vdaas.org"
+          git remote set-url origin "https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git submodule update --init --recursive
           ls -la ./public/
       - name: Link Check
         id: lychee

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -24,7 +24,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v1
         with:
-          args: --base ./public/docs ./public/docs/**/index.html --exclude https://github.com/vdaas/*
+          args: --base ./content/docs ./content/docs/**/*.md --exclude https://github.com/vdaas/*
           output: ./check.md
           fail: false
       - name: Create Issue From File

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -20,12 +20,11 @@ jobs:
           git config --global user.email "ci@vdaas.org"
           git remote set-url origin "https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git submodule update --init --recursive
-          ls -la ./public/
       - name: Link Check
         id: lychee
         uses: lycheeverse/lychee-action@v1
         with:
-          args: --base . --verbose './public/docs/**/*.html' --exclude https://github.com/vdaas/*
+          args: --base ./public/docs --verbose './public/docs/**/*.html' --exclude https://github.com/vdaas/*
           output: ./check.md
           fail: false
       - name: Create Issue From File

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -24,7 +24,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v1
         with:
-          args: --base ./public/docs --verbose './public/docs/**/*.html' --exclude https://github.com/vdaas/*
+          args: --base ./public/docs --verbose './public/docs/**/index.html' --exclude https://github.com/vdaas/*
           output: ./check.md
           fail: false
       - name: Create Issue From File
@@ -36,4 +36,5 @@ jobs:
       - name: Add Comment On Pull Request From File
         if: env.lychee_exit_code != 0 && github.event_name == 'pull_request'
         run: |
+          cat ./check.md
           gh pr comment ${{ github.event.number }} --body-file ./check.md

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,34 @@
+name: Link Check
+on:
+  repository_dispatch:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+
+env:
+  GITHUB_USER: ${{ secrets.DISPATCH_USER }}
+  GITHUB_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+
+jobs:
+  linkCheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v4
+      - name: Link Check
+        id: lychee
+        uses: lycheeverse/lychee-actions@v1
+        with:
+          args: --base https://vald.vdaas/org/docs
+          output: ./result.md
+          fail: false
+      - name: Create Issue From File
+        if: env.lychee_exit_code != 0 && github.event_name != 'pull_request'
+        run: |
+          ISSUE_TITLE="Dead Links were detected"
+          gh issue create --title ISSUE_TITLE \
+                          --body-file ./result.md
+      - name: Add Comment On Pull Request From File
+        if: env.lychee_exit_code != 0 && github.event_name == 'pull_request'
+        run: |
+          gh pr comment ${{ github.event.number }} --body-file ./result.md

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -17,6 +17,7 @@ jobs:
         run: |
           git submodule init
           make subup
+          ls -la ./public/
       - name: Link Check
         id: lychee
         uses: lycheeverse/lychee-action@v1

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -24,7 +24,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v1
         with:
-          args: --base ./public/docs ./public/docs/**/*.html --exclude https://github.com/vdaas/*
+          args: --base . ./public/docs/**/*.html --exclude https://github.com/vdaas/*
           output: ./check.md
           fail: false
       - name: Create Issue From File

--- a/themes/vald/layouts/partials/googleanalytics.html
+++ b/themes/vald/layouts/partials/googleanalytics.html
@@ -1,4 +1,4 @@
-{{ if lot hugo.IsServer }}
+{{ if not hugo.IsServer }}
   {{ with .Site.Config.Services.GoogleAnalytics.ID }}
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>

--- a/themes/vald/layouts/partials/googleanalytics.html
+++ b/themes/vald/layouts/partials/googleanalytics.html
@@ -1,5 +1,5 @@
-{{ if not .Site.IsServer }}
-  {{ with .Site.GoogleAnalytics }}
+{{ if lot hugo.IsServer }}
+  {{ with .Site.Config.Services.GoogleAnalytics.ID }}
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
     <script>

--- a/themes/vald/layouts/partials/style.html
+++ b/themes/vald/layouts/partials/style.html
@@ -1,4 +1,4 @@
-{{ if not .Site.IsServer }}
+{{ if not hugo.IsServer }}
   <link rel="stylesheet" type="text/css" href="/css/style.min.css">
   <link rel="stylesheet" type="text/css" href="/css/header.min.css">
   <link rel="stylesheet" type="text/css" href="/css/footer.min.css">


### PR DESCRIPTION
I have created a new workflow for checking dead links in [the official website](https://vald.vdaas.ord/docs/) using [lycheeverse/lychee](https://github.com/lycheeverse/lychee-action).

I set the 3 triggers for running this workflow:
1. manually Dispatch
2. Pull Request
3. Cron (everyday 00:00:00)

When this workflow runs, triggered by a Pull Request and the `exited_code != 0`, the result will be posted on the target PR conversation.
Also, the result will be posted as a new issue when it runs as a cron job.